### PR TITLE
cargo: make `mold` link arg compatible with GCC < 12.1.0

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -7,11 +7,11 @@ xtask = "run --package xtask --"
 
 [target.x86_64-unknown-linux-gnu]
 linker = "clang"
-rustflags = ["-C", "link-arg=-fuse-ld=mold"]
+rustflags = ["-C", "link-arg=-Bmold"]
 
 [target.aarch64-unknown-linux-gnu]
 linker = "clang"
-rustflags = ["-C", "link-arg=-fuse-ld=mold"]
+rustflags = ["-C", "link-arg=-Bmold"]
 
 # This cfg will reduce the size of `windows::core::Error` from 16 bytes to 4 bytes
 [target.'cfg(target_os = "windows")']


### PR DESCRIPTION
When zed cross-compiles zed-remote-server(host: MacOS Apple Silicion and Docker Desktop, remote: aarchlinux64 linux), the GCC version in the auto used image `cross-rs/cross-custom-zed:aarch64-unknown-linux-gnu-8d728` is `9.4.0`, which does not support the `-fuse-ld=mold` parameter but requires [-Bmold](https://github.com/rui314/mold?tab=readme-ov-file#how-to-use) , otherwise it reports an error.

```
$ docker run -it localhost/cross-rs/cross-custom-zed:aarch64-unknown-linux-gnu-8d728 aarch64-linux-gnu-gcc --version |head -1
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
aarch64-linux-gnu-gcc (Ubuntu 9.4.0-1ubuntu1~20.04.2) 9.4.0
```

zed Debug Log:

```
...
 "/Users/alizj/.rustup/toolchains/1.81-x86_64-unknown-linux-gnu/lib/rustlib/aarch64-unknown-linux-gnu/lib/libcompiler_builtins-405c9891256dbf91.rlib" "-Wl,-Bdynamic" "-lgcc_s" "-lutil" "-lrt" "-lpthread" "-lm" "-ldl" "-lc" "-Wl,--eh-frame-hdr" "-Wl,-z,noexecstack" "-L" "/Users/alizj/.rustup/toolchains/1.81-x86_64-unknown-linux-gnu/lib/rustlib/aarch64-unknown-linux-gnu/lib" "-o" "/target/aarch64-unknown-linux-gnu/debug/deps/libzune_jpeg-d98812c935e11704.so" "-Wl,--gc-sections" "-shared" "-Wl,-soname=libzune_jpeg-d98812c935e11704.so" "-Wl,-z,relro,-z,now" "-nodefaultlibs" "-fuse-ld=mold"
      = note: aarch64-linux-gnu-gcc: error: unrecognized command line option '-fuse-ld=mold'; did you mean '-fuse-ld=gold'?
```

Closes #ISSUE

Release Notes:

- N/A *or* Added/Fixed/Improved ...
